### PR TITLE
feat:Add Windows 7 and LoongArch old world build support

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: "!(*musl*|*windows-arm64*|*android*|*freebsd*)" # xgo and loongarch
+          - target: "!(*musl*|*windows-arm64*|*windows-7*|*android*|*freebsd*)" # xgo and loongarch
             hash: "md5"
           - target: "linux-!(arm*)-musl*" #musl-not-arm
             hash: "md5-linux-musl"
@@ -69,6 +69,8 @@ jobs:
             hash: "md5-linux-musl-arm"
           - target: "windows-arm64" #win-arm64
             hash: "md5-windows-arm64"
+          - target: "windows-7-*" #win7
+            hash: "md5-windows-7"
           - target: "android-*" #android
             hash: "md5-android"
           - target: "freebsd-*" #freebsd
@@ -92,7 +94,65 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
+      - name: Build (Win7)
+        if: matrix.hash == 'md5-windows-7'
+        run: |
+          # Install MinGW-w64 cross-compilation toolchain for Win7 compatibility
+          echo "Installing MinGW-w64 toolchain for Windows 7 compatibility..."
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
+          
+          # Setup Win7 Go compiler (patched version that supports Windows 7)
+          go_version=$(go version | grep -o 'go[0-9]\+\.[0-9]\+\.[0-9]\+' | sed 's/go//')
+          echo "Detected Go version: $go_version"
+          
+          curl -fsSL --retry 3 -o go-win7.zip -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://github.com/XTLS/go-win7/releases/download/patched-${go_version}/go-for-win7-linux-amd64.zip"
+          
+          rm -rf go-win7
+          unzip go-win7.zip -d go-win7
+          rm go-win7.zip
+          
+          # Set permissions for wrapper files
+          chmod +x ./wrapper/zcc-win7
+          chmod +x ./wrapper/zcxx-win7
+          chmod +x ./wrapper/zcc-win7-386
+          chmod +x ./wrapper/zcxx-win7-386
+          
+          # Create build directory
+          mkdir -p build
+          
+          # Build for both 386 and amd64 architectures
+          for arch in "386" "amd64"; do
+            echo "building for windows-7-${arch}"
+            export GOOS=windows
+            export GOARCH=${arch}
+            export CGO_ENABLED=1
+            
+            # Use architecture-specific wrapper files
+            if [ "$arch" = "386" ]; then
+              export CC=$(pwd)/wrapper/zcc-win7-386
+              export CXX=$(pwd)/wrapper/zcxx-win7-386
+            else
+              export CC=$(pwd)/wrapper/zcc-win7
+              export CXX=$(pwd)/wrapper/zcxx-win7
+            fi
+            
+            # Build with ldflags
+            $(pwd)/go-win7/bin/go build -o "./build/openlist-windows-7-${arch}.exe" \
+              -ldflags="-w -s \
+                -X 'github.com/OpenListTeam/OpenList/v4/internal/conf.BuiltAt=$(date +'%F %T %z')' \
+                -X 'github.com/OpenListTeam/OpenList/v4/internal/conf.GitAuthor=OpenList' \
+                -X 'github.com/OpenListTeam/OpenList/v4/internal/conf.GitCommit=$(git log --pretty=format:\"%h\" -1)' \
+                -X 'github.com/OpenListTeam/OpenList/v4/internal/conf.Version=beta' \
+                -X 'github.com/OpenListTeam/OpenList/v4/internal/conf.WebVersion=dev'" \
+              -tags=jsoniter .
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (Other targets)
+        if: matrix.hash != 'md5-windows-7'
         uses: OpenListTeam/cgo-actions@v1.2.2
         with:
           targets: ${{ matrix.target }}

--- a/wrapper/zcc-win7
+++ b/wrapper/zcc-win7
@@ -1,0 +1,2 @@
+#!/bin/sh
+zig cc -target x86_64-windows-gnu $@

--- a/wrapper/zcc-win7
+++ b/wrapper/zcc-win7
@@ -1,2 +1,2 @@
 #!/bin/sh
-zig cc -target x86_64-windows-gnu $@
+x86_64-w64-mingw32-gcc $@

--- a/wrapper/zcc-win7-386
+++ b/wrapper/zcc-win7-386
@@ -1,0 +1,2 @@
+#!/bin/sh
+zig cc -target x86-windows-gnu $@

--- a/wrapper/zcc-win7-386
+++ b/wrapper/zcc-win7-386
@@ -1,2 +1,2 @@
 #!/bin/sh
-zig cc -target x86-windows-gnu $@
+i686-w64-mingw32-gcc $@

--- a/wrapper/zcxx-win7
+++ b/wrapper/zcxx-win7
@@ -1,0 +1,2 @@
+#!/bin/sh
+zig c++ -target x86_64-windows-gnu $@

--- a/wrapper/zcxx-win7
+++ b/wrapper/zcxx-win7
@@ -1,2 +1,2 @@
 #!/bin/sh
-zig c++ -target x86_64-windows-gnu $@
+x86_64-w64-mingw32-g++ $@

--- a/wrapper/zcxx-win7-386
+++ b/wrapper/zcxx-win7-386
@@ -1,0 +1,2 @@
+#!/bin/sh
+zig c++ -target x86-windows-gnu $@

--- a/wrapper/zcxx-win7-386
+++ b/wrapper/zcxx-win7-386
@@ -1,2 +1,2 @@
 #!/bin/sh
-zig c++ -target x86-windows-gnu $@
+i686-w64-mingw32-g++ $@


### PR DESCRIPTION
- Add BuildWin7() function with patched Go compiler for Windows 7 compatibility
- Add BuildLoongOldWorld() function for linux-loong64-abi1.0 target
- Create Zig-based wrapper scripts for Windows 7 cross-compilation
- Integrate new build functions into existing release workflows